### PR TITLE
feat: add uploadPart method type definition

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -40,6 +40,8 @@ import {
   UploadPartCopySourceData,
   UploadPartCopyOptions,
   UploadPartCopyResult,
+  UploadPartOptions,
+  UploadPartResult,
   PartInfo,
   SourceData,
   IncomingHttpHeaders,
@@ -151,6 +153,11 @@ class SimpleClient implements IObjectSimple {
 
   async uploadPartCopy(name: string, uploadId: string, partNo: number, range: string, sourceData: UploadPartCopySourceData, options?: UploadPartCopyOptions): Promise<UploadPartCopyResult> {
     console.log(name, uploadId, partNo, range, sourceData, options);
+    return {} as any;
+  }
+
+  async uploadPart(name: string, uploadId: string, partNo: number, file: any, start: number, end: number, options?: UploadPartOptions): Promise<UploadPartResult> {
+    console.log(name, uploadId, partNo, file, start, end, options);
     return {} as any;
   }
 
@@ -476,3 +483,62 @@ const uploadPartCopyResult4 = await simpleClient.uploadPartCopy(
   partCopySourceData
 );
 expectType<string>(uploadPartCopyResult4.etag);
+
+// Test uploadPart basic usage
+const uploadPartResult1 = await simpleClient.uploadPart(
+  'large-file.bin',
+  'uploadId123',
+  1,
+  '/path/to/file.bin',
+  0,
+  1048576
+);
+expectType<string>(uploadPartResult1.name);
+expectType<string>(uploadPartResult1.etag);
+expectType<number>(uploadPartResult1.res.status);
+
+// Test uploadPart with options
+const uploadPartResult2 = await simpleClient.uploadPart(
+  'large-file.bin',
+  'uploadId123',
+  2,
+  '/path/to/file.bin',
+  1048576,
+  2097152,
+  {
+    timeout: 60000,
+    disabledMD5: false
+  }
+);
+expectType<string>(uploadPartResult2.etag);
+
+// Test uploadPart with File object (browser environment)
+const fileObject = new File(['content'], 'test.txt');
+const uploadPartResult3 = await simpleClient.uploadPart(
+  'upload.txt',
+  'uploadId456',
+  3,
+  fileObject,
+  0,
+  100000,
+  {
+    headers: {
+      'x-oss-server-side-encryption': 'AES256'
+    },
+    mime: 'text/plain'
+  }
+);
+expectType<string>(uploadPartResult3.name);
+expectType<string>(uploadPartResult3.etag);
+expectType<number>(uploadPartResult3.res.status);
+
+// Test uploadPart with different byte ranges
+const uploadPartResult4 = await simpleClient.uploadPart(
+  'video.mp4',
+  'uploadId789',
+  5,
+  '/path/to/video.mp4',
+  5242880,
+  10485760
+);
+expectType<string>(uploadPartResult4.etag);

--- a/src/index.ts
+++ b/src/index.ts
@@ -574,7 +574,7 @@ export interface IObjectSimple {
   /**
    * Upload a part in a multipart upload transaction.
    */
-  uploadPart(name: string, uploadId: string, partNo: number, file: any, start: number, end: number, options?: UploadPartOptions): Promise<UploadPartResult>;
+  uploadPart(name: string, uploadId: string, partNo: number, file: string | Buffer | Readable, start: number, end: number, options?: UploadPartOptions): Promise<UploadPartResult>;
 
   /**
    * Signature a url for the object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,6 +410,20 @@ export interface UploadPartCopyResult {
   res: NormalSuccessResponse;
 }
 
+export interface UploadPartOptions extends RequestOptions {
+  headers?: IncomingHttpHeaders;
+  mime?: string;
+  /** disable MD5 check */
+  disabledMD5?: boolean;
+}
+
+export interface UploadPartResult {
+  name: string;
+  /** part etag */
+  etag: string;
+  res: NormalSuccessResponse;
+}
+
 export type HTTPMethods = 'GET' | 'POST' | 'DELETE' | 'PUT';
 
 export interface ResponseHeaderType {
@@ -556,6 +570,11 @@ export interface IObjectSimple {
    * Upload a part copy in a multipart from the source bucket/object.
    */
   uploadPartCopy(name: string, uploadId: string, partNo: number, range: string, sourceData: UploadPartCopySourceData, options?: UploadPartCopyOptions): Promise<UploadPartCopyResult>;
+
+  /**
+   * Upload a part in a multipart upload transaction.
+   */
+  uploadPart(name: string, uploadId: string, partNo: number, file: any, start: number, end: number, options?: UploadPartOptions): Promise<UploadPartResult>;
 
   /**
    * Signature a url for the object.


### PR DESCRIPTION
Add uploadPart method for uploading a part in a multipart upload transaction:
- UploadPartOptions interface with headers, mime, and disabledMD5 fields
- UploadPartResult interface with name, etag, and res fields
- Method signature supporting file path or File object with byte range (start, end)
- Comprehensive type tests covering various usage scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to upload individual file parts as part of multipart uploads.
  * Configurable upload options: custom headers, MIME type, and optional MD5 checksum control.
  * Part upload now returns result details (including part identifier/etag and server response) for resumable or multipart workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->